### PR TITLE
Fix "fan on" command

### DIFF
--- a/data/src/main/java/com/nairbspace/octoandroid/data/entity/ArbitraryCommandEntity.java
+++ b/data/src/main/java/com/nairbspace/octoandroid/data/entity/ArbitraryCommandEntity.java
@@ -11,7 +11,7 @@ import java.util.List;
 @AutoGson(autoValueClass = AutoValue_ArbitraryCommandEntity.class)
 public abstract class ArbitraryCommandEntity {
     private static final String COMMAND_MOTORS_OFF = "M18";
-    private static final String COMMAND_FAN_ON = "M105";
+    private static final String COMMAND_FAN_ON = "M106";
     private static final String COMMAND_FAN_OFF = "M106 S0";
 
     @SerializedName("commands") public abstract List<String> commands();


### PR DESCRIPTION
The general command "fan on" doesn't work in the current release. This is probably due to a wrong command code, the correct code should be `M106` instead of `M105` according to the [RepRap wiki](http://reprap.org/wiki/G-code#M106:_Fan_On).
